### PR TITLE
Add requeue parameter to nack, tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ function init(behaviour) {
           var ackFun = function () {
             subChannel.ack(message);
           };
-          var nackFun = function () {
-            subChannel.nack(message);
+          var nackFun = function (requeue) {
+            subChannel.nack(message, false, requeue);
           };
           var decodedMessage;
           try {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Jens Carlén",
     "Pål Edman"
   ],
-  "version": "2.3.2",
+  "version": "2.3.3",
   "scripts": {
     "pretest": "docker-compose build",
     "test": "docker-compose run app \"cd /app && node_modules/.bin/mocha\"",


### PR DESCRIPTION
- Expose `requeue` parameter to our `nack` function, enabling library user to specify requeueing behaviour.
- Add test for nack with requeue=false
- Add test for dead letter exchange